### PR TITLE
add more optional module locations

### DIFF
--- a/CMakeLists.txt.island_epilog.in
+++ b/CMakeLists.txt.island_epilog.in
@@ -17,9 +17,6 @@ if (PLUGINS_DYNAMIC)
     target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINS_DYNAMIC=1")
 endif()
 
-# add module include directories
-include_directories("$<BUILD_INTERFACE:${MODULE_LOCATIONS_LIST}>")
-
 # we need to link in the dynamic linking library so we can use dynamic linking
 target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
 

--- a/CMakeLists.txt.island_epilog.in
+++ b/CMakeLists.txt.island_epilog.in
@@ -17,6 +17,9 @@ if (PLUGINS_DYNAMIC)
     target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINS_DYNAMIC=1")
 endif()
 
+# add module include directories
+include_directories("$<BUILD_INTERFACE:${MODULE_LOCATIONS_LIST}>")
+
 # we need to link in the dynamic linking library so we can use dynamic linking
 target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
 

--- a/CMakeLists.txt.island_prolog.in
+++ b/CMakeLists.txt.island_prolog.in
@@ -92,13 +92,14 @@ endif()
 # include the island base directory
 include_directories ("${ISLAND_BASE_DIR}")
 
-# keep this include to not break backwards compatibility with projects that did not use MODULE_LOCATIONS_LIST yet
+# keep this include to not break backwards compatibility with projects that did not 
+# use MODULE_LOCATIONS_LIST yet
 include_directories ("${ISLAND_BASE_DIR}/modules")
 
 # These modules are always loaded - they control the plugin system.
 set ( ISLAND_LOADER_MODULES le_file_watcher;le_core )
 
-# These modules form the renderer - if you want to draw graphics, you want these.
+# These modules from the renderer - if you want to draw graphics, you want these.
 # Note that order matters: dependent modules must be named before their dependencies.
 set ( CORE_ISLAND_MODULES le_pipeline_builder;le_window;le_backend_vk;le_swapchain_vk;le_renderer;le_jobs;le_shader_compiler)
 

--- a/CMakeLists.txt.island_prolog.in
+++ b/CMakeLists.txt.island_prolog.in
@@ -89,12 +89,27 @@ if (REQUIRES_ISLAND_CORE)
     endif()
 endif()
 
+# Adds a directory to the modules locations
+macro(add_island_module_location MODULE_LOCATION)
+    set( MODULE_LOCATIONS_LIST ${MODULE_LOCATIONS_LIST} ${MODULE_LOCATION} CACHE INTERNAL "module_locations_list" )
+    include_directories("${MODULE_LOCATIONS_LIST}")
+endmacro()
+
+
 # include the island base directory
 include_directories ("${ISLAND_BASE_DIR}")
 
-# keep this include to not break backwards compatibility with projects that did not 
-# use MODULE_LOCATIONS_LIST yet
-include_directories ("${ISLAND_BASE_DIR}/modules")
+# We will store all possible module locations in this list, if the same module exists in multiple locations, the last one will be used
+set ( MODULE_LOCATIONS_LIST CACHE INTERNAL "module_locations_list")
+
+# Set default island module location
+add_island_module_location("${ISLAND_BASE_DIR}/modules")
+
+# We will store all requested module names in this list, and then load modules based on this list
+set ( MODULES_LIST )
+
+# We will store all loaded module names in this global list, so that we can make sure that modules don't get loaded more than once.
+set ( LOADED_MODULES_LIST CACHE INTERNAL "loaded_modules_list" )
 
 # These modules are always loaded - they control the plugin system.
 set ( ISLAND_LOADER_MODULES le_file_watcher;le_core )
@@ -102,15 +117,6 @@ set ( ISLAND_LOADER_MODULES le_file_watcher;le_core )
 # These modules from the renderer - if you want to draw graphics, you want these.
 # Note that order matters: dependent modules must be named before their dependencies.
 set ( CORE_ISLAND_MODULES le_pipeline_builder;le_window;le_backend_vk;le_swapchain_vk;le_renderer;le_jobs;le_shader_compiler)
-
-# We will store all requested module names in this list, and then load modules based on this list
-set ( MODULES_LIST )
-
-# We will store all possible module locations in this list, if the same module exists in multiple locations, the last one will be used
-set ( MODULE_LOCATIONS_LIST "${ISLAND_BASE_DIR}/modules/" CACHE INTERNAL "module_locations_list")
-
-# We will store all loaded module names in this global list, so that we can make sure that modules don't get loaded more than once.
-set ( LOADED_MODULES_LIST CACHE INTERNAL "loaded_modules_list" )
 
 # Add required modules to modules list based on user flags
 #
@@ -121,12 +127,6 @@ endif()
 if (REQUIRES_ISLAND_CORE)
    list (APPEND MODULES_LIST ${CORE_ISLAND_MODULES})
 endif()
-
-# Adds a directory to the modules locations
-macro(add_island_module_location MODULE_LOCATION)
-    set( MODULE_LOCATIONS_LIST ${MODULE_LOCATIONS_LIST} ${MODULE_LOCATION} CACHE INTERNAL "module_locations_list" )
-    include_directories("${MODULE_LOCATIONS_LIST}")
-endmacro()
 
 # Loads a requested module
 # Note that this method is only called in epilog - this is a mechanism to make sure 

--- a/CMakeLists.txt.island_prolog.in
+++ b/CMakeLists.txt.island_prolog.in
@@ -125,14 +125,11 @@ endif()
 # Adds a directory to the modules locations
 macro(add_island_module_location MODULE_LOCATION)
     set( MODULE_LOCATIONS_LIST ${MODULE_LOCATIONS_LIST} ${MODULE_LOCATION} CACHE INTERNAL "module_locations_list" )
+    include_directories("${MODULE_LOCATIONS_LIST}")
 endmacro()
 
 # Loads a requested module
 macro(load_island_module MODULE_NAME)
-
-    # add all module directories to the include path of the module,
-    # due to macro scope this will only apply to the current module
-    include_directories(${MODULE_LOCATIONS_LIST})
 
     # look for the module in all given locations
     set( MODULE_LOCATION )

--- a/CMakeLists.txt.island_prolog.in
+++ b/CMakeLists.txt.island_prolog.in
@@ -129,6 +129,8 @@ macro(add_island_module_location MODULE_LOCATION)
 endmacro()
 
 # Loads a requested module
+# Note that this method is only called in epilog - this is a mechanism to make sure 
+# we have a consolidated, unique list of modules by the time we load modules.
 macro(load_island_module MODULE_NAME)
 
     # look for the module in all given locations

--- a/CMakeLists.txt.island_prolog.in
+++ b/CMakeLists.txt.island_prolog.in
@@ -89,7 +89,10 @@ if (REQUIRES_ISLAND_CORE)
     endif()
 endif()
 
+# include the island base directory
 include_directories ("${ISLAND_BASE_DIR}")
+
+# keep this include to not break backwards compatibility with projects that did not use MODULE_LOCATIONS_LIST yet
 include_directories ("${ISLAND_BASE_DIR}/modules")
 
 # These modules are always loaded - they control the plugin system.
@@ -121,11 +124,14 @@ endif()
 # Adds a directory to the modules locations
 macro(add_island_module_location MODULE_LOCATION)
     set( MODULE_LOCATIONS_LIST ${MODULE_LOCATIONS_LIST} ${MODULE_LOCATION} CACHE INTERNAL "module_locations_list" )
-    message( ${MODULE_LOCATIONS_LIST} )
 endmacro()
 
 # Loads a requested module
 macro(load_island_module MODULE_NAME)
+
+    # add all module directories to the include path of the module,
+    # due to macro scope this will only apply to the current module
+    include_directories(${MODULE_LOCATIONS_LIST})
 
     # look for the module in all given locations
     set( MODULE_LOCATION )
@@ -254,4 +260,3 @@ macro(add_dynamic_linker_flags)
 
     
 endmacro(add_dynamic_linker_flags)
-

--- a/CMakeLists.txt.island_prolog.in
+++ b/CMakeLists.txt.island_prolog.in
@@ -102,9 +102,11 @@ set ( CORE_ISLAND_MODULES le_pipeline_builder;le_window;le_backend_vk;le_swapcha
 # We will store all requested module names in this list, and then load modules based on this list
 set ( MODULES_LIST )
 
+# We will store all possible module locations in this list, if the same module exists in multiple locations, the last one will be used
+set ( MODULE_LOCATIONS_LIST "${ISLAND_BASE_DIR}/modules/" CACHE INTERNAL "module_locations_list")
+
 # We will store all loaded module names in this global list, so that we can make sure that modules don't get loaded more than once.
 set ( LOADED_MODULES_LIST CACHE INTERNAL "loaded_modules_list" )
-
 
 # Add required modules to modules list based on user flags
 #
@@ -116,10 +118,30 @@ if (REQUIRES_ISLAND_CORE)
    list (APPEND MODULES_LIST ${CORE_ISLAND_MODULES})
 endif()
 
+# Adds a directory to the modules locations
+macro(add_island_module_location MODULE_LOCATION)
+    set( MODULE_LOCATIONS_LIST ${MODULE_LOCATIONS_LIST} ${MODULE_LOCATION} CACHE INTERNAL "module_locations_list" )
+    message( ${MODULE_LOCATIONS_LIST} )
+endmacro()
+
 # Loads a requested module
 macro(load_island_module MODULE_NAME)
-    message(STATUS "Loading module  : ${MODULE_NAME}")
-    add_subdirectory ("${ISLAND_BASE_DIR}/modules/${MODULE_NAME}" ${MODULE_NAME})
+
+    # look for the module in all given locations
+    set( MODULE_LOCATION )
+    foreach( LOCATION ${MODULE_LOCATIONS_LIST} )
+        set( CURRENT_LOCATION "${LOCATION}/${MODULE_NAME}" )
+        if( EXISTS ${CURRENT_LOCATION} )
+            set( MODULE_LOCATION ${CURRENT_LOCATION} )
+        endif()
+    endforeach()
+
+    if( MODULE_LOCATION )
+        message(STATUS "Loading module  : ${MODULE_NAME}")
+        add_subdirectory (${MODULE_LOCATION} ${MODULE_NAME})
+    else()
+        message( SEND_ERROR "Module not found  : ${MODULE_NAME}")
+    endif()
 endmacro()
 
 # Call this macro from other modules to establish a dependency.
@@ -232,3 +254,4 @@ macro(add_dynamic_linker_flags)
 
     
 endmacro(add_dynamic_linker_flags)
+

--- a/apps/examples/asterisks/CMakeLists.txt
+++ b/apps/examples/asterisks/CMakeLists.txt
@@ -13,7 +13,7 @@ project (${PROJECT_NAME})
 # add_compile_definitions( LE_MT=4 )
 
 # Vulkan Validation layers are enabled by default for Debug builds.
-# Uncomment the next line to disable loading Vulkan Validation Layers for Debug builds.
+# Uncomment the next line to disable loading Vulkan Validation Layers.
 # add_compile_definitions( SHOULD_USE_VALIDATION_LAYERS=false )
 
 # Point this to the base directory of your Island installation
@@ -26,16 +26,22 @@ set(REQUIRES_ISLAND_CORE ON )
 # Loads Island framework, based on selected Island modules from above
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
+# Add custom module search paths
+# add_island_module_location(${PROJECT_SOURCE_DIR}/../../modules)
+
+# Main application c++ file. Not much to see there,
+set (SOURCES main.cpp)
+
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
 add_subdirectory (asterisks_app)
 
-# Specify any optional modules from the standard framework here
+# Specify any used modules here - you may reference any module 
+# found in the default Island modules/ directory, or found in any 
+# directories you specified via `add_island_module_location` above.
+#
 add_island_module(le_camera)
 add_island_module(le_ecs)
-
-# Main application c++ file. Not much to see there,
-set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")

--- a/apps/examples/asterisks/CMakeLists.txt
+++ b/apps/examples/asterisks/CMakeLists.txt
@@ -24,7 +24,7 @@ set(REQUIRES_ISLAND_LOADER ON )
 set(REQUIRES_ISLAND_CORE ON )
 
 # Loads Island framework, based on selected Island modules from above
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
@@ -38,7 +38,7 @@ add_island_module(le_ecs)
 set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_epilog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # (optional) create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)

--- a/apps/examples/compute_example/CMakeLists.txt
+++ b/apps/examples/compute_example/CMakeLists.txt
@@ -13,7 +13,7 @@ set(REQUIRES_ISLAND_LOADER ON )
 set(REQUIRES_ISLAND_CORE ON )
 
 # Loads Island framework, based on selected Island modules from above
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
@@ -28,7 +28,7 @@ add_island_module(le_mesh_generator)
 set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_epilog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)

--- a/apps/examples/compute_example/CMakeLists.txt
+++ b/apps/examples/compute_example/CMakeLists.txt
@@ -3,7 +3,18 @@ set (CMAKE_CXX_STANDARD 17)
 
 set (PROJECT_NAME "Island-ComputeExample")
 
+# Set global property (all targets are impacted)
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
+
 project (${PROJECT_NAME})
+
+# set to number of worker threads if you wish to use multi-threaded rendering
+# add_compile_definitions( LE_MT=4 )
+
+# Vulkan Validation layers are enabled by default for Debug builds.
+# Uncomment the next line to disable loading Vulkan Validation Layers.
+# add_compile_definitions( SHOULD_USE_VALIDATION_LAYERS=false )
 
 # Point this to the base directory of your Island installation
 set (ISLAND_BASE_DIR "${PROJECT_SOURCE_DIR}/../../../")
@@ -15,17 +26,24 @@ set(REQUIRES_ISLAND_CORE ON )
 # Loads Island framework, based on selected Island modules from above
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
+# Add custom module search paths
+# add_island_module_location(${PROJECT_SOURCE_DIR}/../../modules)
+
+# Main application c++ file. Not much to see there,
+set (SOURCES main.cpp)
+
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
 add_subdirectory (compute_example_app)
 
-# Specify any optional modules from the standard framework here
+# Specify any used modules here - you may reference any module 
+# found in the default Island modules/ directory, or found in any 
+# directories you specified via `add_island_module_location` above.
+#
 add_island_module(le_pipeline_builder)
 add_island_module(le_camera)
 add_island_module(le_mesh_generator)
 
-# Main application c++ file. Not much to see there,
-set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
@@ -33,4 +51,6 @@ include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)
 set_target_properties(${PROJECT_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+source_group(${PROJECT_NAME} FILES ${SOURCES})
         

--- a/apps/examples/hello_triangle/CMakeLists.txt
+++ b/apps/examples/hello_triangle/CMakeLists.txt
@@ -26,15 +26,21 @@ set(REQUIRES_ISLAND_CORE ON )
 # Loads Island framework, based on selected Island modules from above
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
+# Add custom module search paths
+# add_island_module_location(${PROJECT_SOURCE_DIR}/../../modules)
+
+# Main application c++ file. Not much to see there,
+set (SOURCES main.cpp)
+
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
 add_subdirectory (hello_triangle_app)
 
-# Specify any optional modules from the standard framework here
+# Specify any used modules here - you may reference any module 
+# found in the default Island modules/ directory, or found in any 
+# directories you specified via `add_island_module_location` above.
+#
 add_island_module(le_camera)
-
-# Main application c++ file. Not much to see there,
-set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")

--- a/apps/examples/hello_triangle/CMakeLists.txt
+++ b/apps/examples/hello_triangle/CMakeLists.txt
@@ -24,7 +24,7 @@ set(REQUIRES_ISLAND_LOADER ON )
 set(REQUIRES_ISLAND_CORE ON )
 
 # Loads Island framework, based on selected Island modules from above
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
@@ -37,7 +37,7 @@ add_island_module(le_camera)
 set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_epilog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # (optional) create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)

--- a/apps/examples/hello_world/CMakeLists.txt
+++ b/apps/examples/hello_world/CMakeLists.txt
@@ -3,7 +3,18 @@ set (CMAKE_CXX_STANDARD 17)
 
 set (PROJECT_NAME "Island-HelloWorld")
 
+# Set global property (all targets are impacted)
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
+
 project (${PROJECT_NAME})
+
+# set to number of worker threads if you wish to use multi-threaded rendering
+# add_compile_definitions( LE_MT=4 )
+
+# Vulkan Validation layers are enabled by default for Debug builds.
+# Uncomment the next line to disable loading Vulkan Validation Layers.
+# add_compile_definitions( SHOULD_USE_VALIDATION_LAYERS=false )
 
 # Point this to the base directory of your Island installation
 set (ISLAND_BASE_DIR "${PROJECT_SOURCE_DIR}/../../../")
@@ -15,20 +26,26 @@ set(REQUIRES_ISLAND_CORE ON )
 # Loads Island framework, based on selected Island modules from above
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
+# Add custom module search paths
+# add_island_module_location(${PROJECT_SOURCE_DIR}/../../modules)
+
+# Main application c++ file. Not much to see there,
+set (SOURCES main.cpp)
+
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
 add_subdirectory (hello_world_app)
 
-# Specify any optional modules from the standard framework here
+# Specify any used modules here - you may reference any module 
+# found in the default Island modules/ directory, or found in any 
+# directories you specified via `add_island_module_location` above.
+#
 add_island_module(le_ui_event)
 add_island_module(le_pipeline_builder)
 add_island_module(le_camera)
 add_island_module(le_mesh)
 add_island_module(le_mesh_generator)
 add_island_module(le_resource_manager)
-
-# Main application c++ file. Not much to see there,
-set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
@@ -37,3 +54,5 @@ include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+source_group(${PROJECT_NAME} FILES ${SOURCES})

--- a/apps/examples/hello_world/CMakeLists.txt
+++ b/apps/examples/hello_world/CMakeLists.txt
@@ -13,7 +13,7 @@ set(REQUIRES_ISLAND_LOADER ON )
 set(REQUIRES_ISLAND_CORE ON )
 
 # Loads Island framework, based on selected Island modules from above
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
@@ -31,7 +31,7 @@ add_island_module(le_resource_manager)
 set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_epilog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)

--- a/apps/examples/imgui_example/CMakeLists.txt
+++ b/apps/examples/imgui_example/CMakeLists.txt
@@ -17,7 +17,7 @@ set(REQUIRES_ISLAND_LOADER ON )
 set(REQUIRES_ISLAND_CORE ON )
 
 # Loads Island framework, based on selected Island modules from above
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
@@ -32,7 +32,7 @@ add_island_module(le_imgui)
 set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_epilog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # (optional) create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)

--- a/apps/examples/imgui_example/CMakeLists.txt
+++ b/apps/examples/imgui_example/CMakeLists.txt
@@ -9,6 +9,13 @@ set (PROJECT_NAME "Island-ImguiExample")
 
 project (${PROJECT_NAME})
 
+# set to number of worker threads if you wish to use multi-threaded rendering
+# add_compile_definitions( LE_MT=4 )
+
+# Vulkan Validation layers are enabled by default for Debug builds.
+# Uncomment the next line to disable loading Vulkan Validation Layers.
+# add_compile_definitions( SHOULD_USE_VALIDATION_LAYERS=false )
+
 # Point this to the base directory of your Island installation
 set (ISLAND_BASE_DIR "${PROJECT_SOURCE_DIR}/../../../")
 
@@ -19,17 +26,23 @@ set(REQUIRES_ISLAND_CORE ON )
 # Loads Island framework, based on selected Island modules from above
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
+# Add custom module search paths
+# add_island_module_location(${PROJECT_SOURCE_DIR}/../../modules)
+
+# Main application c++ file. Not much to see there,
+set (SOURCES main.cpp)
+
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
 add_subdirectory (imgui_example_app)
 
-# Specify any optional modules from the standard framework here
+# Specify any used modules here - you may reference any module 
+# found in the default Island modules/ directory, or found in any 
+# directories you specified via `add_island_module_location` above.
+#
 add_island_module(le_pipeline_builder)
 add_island_module(le_camera)
 add_island_module(le_imgui)
-
-# Main application c++ file. Not much to see there,
-set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
@@ -37,3 +50,4 @@ include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 # (optional) create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)
 set_target_properties(${PROJECT_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+source_group(${PROJECT_NAME} FILES ${SOURCES})

--- a/apps/examples/lut_grading_example/CMakeLists.txt
+++ b/apps/examples/lut_grading_example/CMakeLists.txt
@@ -3,7 +3,18 @@ set (CMAKE_CXX_STANDARD 17)
 
 set (PROJECT_NAME "Island-LutGradingExample")
 
+# Set global property (all targets are impacted)
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
+
 project (${PROJECT_NAME})
+
+# set to number of worker threads if you wish to use multi-threaded rendering
+# add_compile_definitions( LE_MT=4 )
+
+# Vulkan Validation layers are enabled by default for Debug builds.
+# Uncomment the next line to disable loading Vulkan Validation Layers.
+# add_compile_definitions( SHOULD_USE_VALIDATION_LAYERS=false )
 
 # Point this to the base directory of your Island installation
 set (ISLAND_BASE_DIR "${PROJECT_SOURCE_DIR}/../../../")
@@ -15,23 +26,29 @@ set(REQUIRES_ISLAND_CORE ON )
 # Loads Island framework, based on selected Island modules from above
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
+# Add custom module search paths
+# add_island_module_location(${PROJECT_SOURCE_DIR}/../../modules)
+
+# Main application c++ file. Not much to see there,
+set (SOURCES main.cpp)
+
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
 add_subdirectory (lut_grading_example_app)
 
-# Specify any optional modules from the standard framework here
-
+# Specify any used modules here - you may reference any module 
+# found in the default Island modules/ directory, or found in any 
+# directories you specified via `add_island_module_location` above.
+#
 add_island_module(le_pixels)
 add_island_module(le_resource_manager)
-
-# Main application c++ file. Not much to see there,
-set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)
+
 set_target_properties(${PROJECT_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 
 source_group(${TARGET} FILES ${SOURCES})

--- a/apps/examples/lut_grading_example/CMakeLists.txt
+++ b/apps/examples/lut_grading_example/CMakeLists.txt
@@ -13,7 +13,7 @@ set(REQUIRES_ISLAND_LOADER ON )
 set(REQUIRES_ISLAND_CORE ON )
 
 # Loads Island framework, based on selected Island modules from above
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
@@ -28,7 +28,7 @@ add_island_module(le_resource_manager)
 set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_epilog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)

--- a/apps/examples/multi_window_example/CMakeLists.txt
+++ b/apps/examples/multi_window_example/CMakeLists.txt
@@ -3,7 +3,18 @@ set (CMAKE_CXX_STANDARD 17)
 
 set (PROJECT_NAME "Island-MultiWindowExample")
 
+# Set global property (all targets are impacted)
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
+
 project (${PROJECT_NAME})
+
+# set to number of worker threads if you wish to use multi-threaded rendering
+# add_compile_definitions( LE_MT=4 )
+
+# Vulkan Validation layers are enabled by default for Debug builds.
+# Uncomment the next line to disable loading Vulkan Validation Layers.
+# add_compile_definitions( SHOULD_USE_VALIDATION_LAYERS=false )
 
 # Point this to the base directory of your Island installation
 set (ISLAND_BASE_DIR "${PROJECT_SOURCE_DIR}/../../../")
@@ -15,20 +26,29 @@ set(REQUIRES_ISLAND_CORE ON )
 # Loads Island framework, based on selected Island modules from above
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
+# Add custom module search paths
+# add_island_module_location(${PROJECT_SOURCE_DIR}/../../modules)
+
+# Main application c++ file. Not much to see there,
+set (SOURCES main.cpp)
+
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
 add_subdirectory (multi_window_example_app)
 
-# Specify any optional modules from the standard framework here
+# Specify any used modules here - you may reference any module 
+# found in the default Island modules/ directory, or found in any 
+# directories you specified via `add_island_module_location` above.
+#
 add_island_module(le_camera)
 add_island_module(le_mesh)
-
-# Main application c++ file. Not much to see there,
-set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)
+
 set_target_properties(${PROJECT_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+source_group(${PROJECT_NAME} FILES ${SOURCES})

--- a/apps/examples/multi_window_example/CMakeLists.txt
+++ b/apps/examples/multi_window_example/CMakeLists.txt
@@ -13,7 +13,7 @@ set(REQUIRES_ISLAND_LOADER ON )
 set(REQUIRES_ISLAND_CORE ON )
 
 # Loads Island framework, based on selected Island modules from above
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
@@ -27,7 +27,7 @@ add_island_module(le_mesh)
 set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_epilog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)

--- a/apps/examples/test_log/CMakeLists.txt
+++ b/apps/examples/test_log/CMakeLists.txt
@@ -23,7 +23,7 @@ set (ISLAND_BASE_DIR "${PROJECT_SOURCE_DIR}/../../../")
 set(REQUIRES_ISLAND_LOADER ON )
 
 # Loads Island framework, based on selected Island modules from above
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
@@ -36,7 +36,7 @@ add_island_module(le_log)
 set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_epilog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)

--- a/apps/examples/test_log/CMakeLists.txt
+++ b/apps/examples/test_log/CMakeLists.txt
@@ -21,19 +21,26 @@ set (ISLAND_BASE_DIR "${PROJECT_SOURCE_DIR}/../../../")
 
 # Select which standard Island modules to use
 set(REQUIRES_ISLAND_LOADER ON )
+# set(REQUIRES_ISLAND_CORE ON )
 
 # Loads Island framework, based on selected Island modules from above
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
+
+# Add custom module search paths
+# add_island_module_location(${PROJECT_SOURCE_DIR}/../../modules)
+
+# Main application c++ file. Not much to see there,
+set (SOURCES main.cpp)
 
 # Add application module, and (optional) any other private
 # island modules which should not be part of the shared framework.
 add_subdirectory (test_log_app)
 
-# Specify any optional modules from the standard framework here
+# Specify any used modules here - you may reference any module 
+# found in the default Island modules/ directory, or found in any 
+# directories you specified via `add_island_module_location` above.
+#
 add_island_module(le_log)
-
-# Main application c++ file. Not much to see there,
-set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
@@ -41,4 +48,7 @@ include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)
 
+set_target_properties(${PROJECT_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+
 source_group(${PROJECT_NAME} FILES ${SOURCES})
+

--- a/apps/templates/quad_template/CMakeLists.txt
+++ b/apps/templates/quad_template/CMakeLists.txt
@@ -13,7 +13,7 @@ project (${PROJECT_NAME})
 # add_compile_definitions( LE_MT=4 )
 
 # Vulkan Validation layers are enabled by default for Debug builds.
-# Uncomment the next line to disable loading Vulkan Validation Layers for Debug builds.
+# Uncomment the next line to disable loading Vulkan Validation Layers.
 # add_compile_definitions( SHOULD_USE_VALIDATION_LAYERS=false )
 
 # Point this to the base directory of your Island installation
@@ -29,19 +29,25 @@ include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 # Add custom module search paths
 # add_island_module_location(${CMAKE_CURRENT_SOURCE_DIR}/modules)
 
-# Add application module, and (optional) any other private
-add_subdirectory (quad_template_app)
-
-# Specify any optional modules from the standard framework here
-add_island_module(le_camera)
-
 # Main application c++ file. Not much to see there,
 set (SOURCES main.cpp)
+
+# Add application module, and (optionally) any other private
+# island modules which should not be part of the shared framework.
+add_subdirectory (quad_template_app)
+
+# Specify any used modules here - you may reference any module 
+# found in the default Island modules/ directory, or found in any 
+# directories you specified via `add_island_module_location` above.
+#
+add_island_module(le_camera)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 
 source_group(${PROJECT_NAME} FILES ${SOURCES})

--- a/apps/templates/quad_template/CMakeLists.txt
+++ b/apps/templates/quad_template/CMakeLists.txt
@@ -26,8 +26,10 @@ set(REQUIRES_ISLAND_CORE ON )
 # Loads Island framework, based on selected Island modules from above
 include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
 
+# Add custom module search paths
+# add_island_module_location(${CMAKE_CURRENT_SOURCE_DIR}/modules)
+
 # Add application module, and (optional) any other private
-# island modules which should not be part of the shared framework.
 add_subdirectory (quad_template_app)
 
 # Specify any optional modules from the standard framework here

--- a/apps/templates/quad_template/CMakeLists.txt
+++ b/apps/templates/quad_template/CMakeLists.txt
@@ -24,7 +24,7 @@ set(REQUIRES_ISLAND_LOADER ON )
 set(REQUIRES_ISLAND_CORE ON )
 
 # Loads Island framework, based on selected Island modules from above
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
 # Add custom module search paths
 # add_island_module_location(${CMAKE_CURRENT_SOURCE_DIR}/modules)
@@ -39,7 +39,7 @@ add_island_module(le_camera)
 set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_epilog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)

--- a/apps/templates/quad_template/quad_template_app/CMakeLists.txt
+++ b/apps/templates/quad_template/quad_template_app/CMakeLists.txt
@@ -22,6 +22,7 @@ else()
 
 endif()
 
+target_include_directories(${TARGET} PUBLIC ${MODULE_LOCATIONS_LIST})
 target_link_libraries(${TARGET} PUBLIC ${LINKER_FLAGS})
 
 source_group(${TARGET} FILES ${SOURCES})

--- a/apps/templates/triangle/CMakeLists.txt
+++ b/apps/templates/triangle/CMakeLists.txt
@@ -27,8 +27,10 @@ set(REQUIRES_ISLAND_CORE ON )
 include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
 
 # Add application module, and (optional) any other private
-# island modules which should not be part of the shared framework.
 add_subdirectory (triangle_app)
+
+# Add custom module search paths
+# add_island_module_location(${CMAKE_CURRENT_SOURCE_DIR}/modules)
 
 # Specify any optional modules from the standard framework here
 add_island_module(le_camera)

--- a/apps/templates/triangle/CMakeLists.txt
+++ b/apps/templates/triangle/CMakeLists.txt
@@ -24,7 +24,7 @@ set(REQUIRES_ISLAND_LOADER ON )
 set(REQUIRES_ISLAND_CORE ON )
 
 # Loads Island framework, based on selected Island modules from above
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_prolog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
 # Add application module, and (optional) any other private
 add_subdirectory (triangle_app)
@@ -39,7 +39,7 @@ add_island_module(le_camera)
 set (SOURCES main.cpp)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
-include ("${ISLAND_BASE_DIR}CMakeLists.txt.island_epilog.in")
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # (optional) create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)

--- a/apps/templates/triangle/CMakeLists.txt
+++ b/apps/templates/triangle/CMakeLists.txt
@@ -26,22 +26,28 @@ set(REQUIRES_ISLAND_CORE ON )
 # Loads Island framework, based on selected Island modules from above
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 
-# Add application module, and (optional) any other private
-add_subdirectory (triangle_app)
-
 # Add custom module search paths
 # add_island_module_location(${CMAKE_CURRENT_SOURCE_DIR}/modules)
 
-# Specify any optional modules from the standard framework here
-add_island_module(le_camera)
-
 # Main application c++ file. Not much to see there,
 set (SOURCES main.cpp)
+
+# Add application module, and (optionally) any other private
+# island modules which should not be part of the shared framework.
+add_subdirectory (triangle_app)
+
+# Specify any used modules here - you may reference any module 
+# found in the default Island modules/ directory, or found in any 
+# directories you specified via `add_island_module_location` above.
+#
+add_island_module(le_camera)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
 
 # (optional) create a link to local resources
 link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 
 source_group(${PROJECT_NAME} FILES ${SOURCES})

--- a/apps/templates/triangle/triangle_app/CMakeLists.txt
+++ b/apps/templates/triangle/triangle_app/CMakeLists.txt
@@ -22,6 +22,7 @@ else()
 
 endif()
 
+target_include_directories(${TARGET} PUBLIC ${MODULE_LOCATIONS_LIST})
 target_link_libraries(${TARGET} PUBLIC ${LINKER_FLAGS})
 
 source_group(${TARGET} FILES ${SOURCES})


### PR DESCRIPTION
Introduces the macro ```add_island_module_location``` All potential module directories are stored in a list which can be extended. 

One use case for this is to have additional modules that are not part of the official island eco system but can still be checked into a git repo together with the app.

Locations added with add_island_module_location take precedence over the default modules directory. This allows modules to be overriden on a per project basis if needed.

```
add_island_module_location(${CMAKE_CURRENT_SOURCE_DIR}/../modules)
```