### PR TITLE
[le_log] apply namespace conventions

### DIFF
--- a/apps/examples/test_log/CMakeLists.txt
+++ b/apps/examples/test_log/CMakeLists.txt
@@ -41,6 +41,7 @@ add_subdirectory (test_log_app)
 # directories you specified via `add_island_module_location` above.
 #
 add_island_module(le_log)
+#add_island_module(le_camera)
 
 # Sets up Island framework linkage and housekeeping, based on user selections
 include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")

--- a/apps/examples/test_log/test_log_app/test_log_app.cpp
+++ b/apps/examples/test_log/test_log_app/test_log_app.cpp
@@ -33,12 +33,12 @@ static test_log_app_o *test_log_app_create() {
 
 static bool test_log_app_update( test_log_app_o *self ) {
 
-	auto logger_2 = le::Log( "logger_2" );
-	logger_2.set_level( le::Log::Level::INFO );
+	auto logger_2 = LeLog( "logger_2" );
+	logger_2.set_level( LeLog::Level::INFO );
 	logger_2.info( "Logger_2 says hello from frame: %d", self->frame_counter );
 	std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
 
-	auto app_logger = le::Log( self->logger );
+	auto app_logger = LeLog( self->logger );
 	app_logger.warn( "oops a warning from the app logger" );
 	std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
 	app_logger.error( "now an error even." );

--- a/modules/le_log/le_log.cpp
+++ b/modules/le_log/le_log.cpp
@@ -38,28 +38,28 @@ static le_log_channel_o *le_log_get_module( const char *name ) {
 	return ctx->modules[ name ];
 }
 
-static void le_log_set_level( le_log_channel_o *module, le::Log::Level level ) {
+static void le_log_set_level( le_log_channel_o *module, LeLog::Level level ) {
 	if ( !module ) {
 		module = le_log_module_default();
 	}
-	module->log_level = static_cast<std::underlying_type<le::Log::Level>::type>( level );
+	module->log_level = static_cast<std::underlying_type<LeLog::Level>::type>( level );
 }
 
-static const char *le_log_level_name( le::Log::Level level ) {
+static const char *le_log_level_name( LeLog::Level level ) {
 	switch ( level ) {
-	case le::Log::Level::DEBUG:
+	case LeLog::Level::DEBUG:
 		return "DEBUG";
-	case le::Log::Level::INFO:
+	case LeLog::Level::INFO:
 		return "INFO";
-	case le::Log::Level::WARN:
+	case LeLog::Level::WARN:
 		return "WARN";
-	case le::Log::Level::ERROR:
+	case LeLog::Level::ERROR:
 		return "ERROR";
 	}
 	return "";
 }
 
-static void le_log_printf( const le_log_channel_o *module, le::Log::Level level, const char *msg, va_list args ) {
+static void le_log_printf( const le_log_channel_o *module, LeLog::Level level, const char *msg, va_list args ) {
 
 	if ( !module ) {
 		module = le_log_module_default();
@@ -71,7 +71,7 @@ static void le_log_printf( const le_log_channel_o *module, le::Log::Level level,
 
 	auto file = stdout;
 
-	if ( level == le::Log::Level::ERROR ) {
+	if ( level == LeLog::Level::ERROR ) {
 		file = stderr;
 	}
 
@@ -83,7 +83,7 @@ static void le_log_printf( const le_log_channel_o *module, le::Log::Level level,
 	fflush( file );
 }
 
-template <le::Log::Level level>
+template <LeLog::Level level>
 static void le_log_implementation( const le_log_channel_o *module, const char *msg, ... ) {
 	va_list arglist;
 	va_start( arglist, msg );
@@ -98,10 +98,10 @@ LE_MODULE_REGISTER_IMPL( le_log, api ) {
 	le_api->get_channel = le_log_get_module;
 
 	auto &le_api_channel_i     = le_api->le_log_channel_i;
-	le_api_channel_i.debug     = le_log_implementation<le::Log::Level::DEBUG>;
-	le_api_channel_i.info      = le_log_implementation<le::Log::Level::INFO>;
-	le_api_channel_i.warn      = le_log_implementation<le::Log::Level::WARN>;
-	le_api_channel_i.error     = le_log_implementation<le::Log::Level::ERROR>;
+	le_api_channel_i.debug     = le_log_implementation<LeLog::Level::DEBUG>;
+	le_api_channel_i.info      = le_log_implementation<LeLog::Level::INFO>;
+	le_api_channel_i.warn      = le_log_implementation<LeLog::Level::WARN>;
+	le_api_channel_i.error     = le_log_implementation<LeLog::Level::ERROR>;
 	le_api_channel_i.set_level = le_log_set_level;
 
 	if ( !le_api->context ) {

--- a/modules/le_log/le_log.h
+++ b/modules/le_log/le_log.h
@@ -40,79 +40,78 @@ LE_MODULE_LOAD_DEFAULT( le_log );
 
 #ifdef __cplusplus
 
-namespace le {
+namespace le_log {
 
 static const auto &api              = le_log_api_i;
 static const auto &le_log_channel_i = api -> le_log_channel_i;
+} // namespace le_log
 
-class Log {
+class LeLog {
 	le_log_channel_o *channel;
 
   public:
 	using Level = le_log_api::Level;
-	Log()
-	    : channel( api->get_channel( nullptr ) ) {
+	LeLog()
+	    : channel( le_log::api->get_channel( nullptr ) ) {
 	}
 
-	Log( le_log_channel_o *channel_ )
+	LeLog( le_log_channel_o *channel_ )
 	    : channel( channel_ ) {
 	}
 
-	Log( char const *channel_name )
-	    : channel( api->get_channel( channel_name ) ) {
+	LeLog( char const *channel_name )
+	    : channel( le_log::api->get_channel( channel_name ) ) {
 	}
 
 	inline void set_level( const Level &level ) {
-		le_log_channel_i.set_level( channel, level );
+		le_log::le_log_channel_i.set_level( channel, level );
 	}
 
 	template <class... Args>
 	inline void debug( const char *msg, Args &&...args ) {
-		le_log_channel_i.debug( channel, msg, static_cast<Args &&>( args )... );
+		le_log::le_log_channel_i.debug( channel, msg, static_cast<Args &&>( args )... );
 	}
 
 	template <class... Args>
 	inline void info( const char *msg, Args &&...args ) {
-		le_log_channel_i.info( channel, msg, static_cast<Args &&>( args )... );
+		le_log::le_log_channel_i.info( channel, msg, static_cast<Args &&>( args )... );
 	}
 
 	template <class... Args>
 	inline void warn( const char *msg, Args &&...args ) {
-		le_log_channel_i.warn( channel, msg, static_cast<Args &&>( args )... );
+		le_log::le_log_channel_i.warn( channel, msg, static_cast<Args &&>( args )... );
 	}
 
 	template <class... Args>
 	inline void error( const char *msg, Args &&...args ) {
-		le_log_channel_i.error( channel, msg, static_cast<Args &&>( args )... );
+		le_log::le_log_channel_i.error( channel, msg, static_cast<Args &&>( args )... );
 	}
 };
 // ----------------------------------------------------------------------
 
-static inline void log_set_level( const Log::Level &level ) {
-	le_log_channel_i.set_level( nullptr, level );
+static inline void le_log_set_level( const LeLog::Level &level ) {
+	le_log::le_log_channel_i.set_level( nullptr, level );
 }
 
 template <typename... Args>
-static inline void log_debug( const char *msg, Args &&...args ) {
-	le_log_channel_i.debug( nullptr, msg, static_cast<Args &&>( args )... );
+static inline void le_log_debug( const char *msg, Args &&...args ) {
+	le_log::le_log_channel_i.debug( nullptr, msg, static_cast<Args &&>( args )... );
 }
 
 template <typename... Args>
-static inline void log_info( const char *msg, Args &&...args ) {
-	le_log_channel_i.info( nullptr, msg, static_cast<Args &&>( args )... );
+static inline void le_log_info( const char *msg, Args &&...args ) {
+	le_log::le_log_channel_i.info( nullptr, msg, static_cast<Args &&>( args )... );
 }
 
 template <typename... Args>
-static inline void log_warn( const char *msg, Args &&...args ) {
-	le_log_channel_i.warn( nullptr, msg, static_cast<Args &&>( args )... );
+static inline void le_log_warn( const char *msg, Args &&...args ) {
+	le_log::le_log_channel_i.warn( nullptr, msg, static_cast<Args &&>( args )... );
 }
 
 template <typename... Args>
-static inline void log_error( const char *msg, Args &&...args ) {
-	le_log_channel_i.error( nullptr, msg, static_cast<Args &&>( args )... );
+static inline void le_log_error( const char *msg, Args &&...args ) {
+	le_log::le_log_channel_i.error( nullptr, msg, static_cast<Args &&>( args )... );
 }
-
-} // namespace le
 
 #endif // __cplusplus
 


### PR DESCRIPTION
* Move c++ facade should into global namespace, but rename it from `le::Log` → `LeLog`

* Move `api` out of global namespace and into namespace `le_log`

This is in line with our conventions for namespaces and naming for modules.

Closes #25 