### PR TITLE
add a directory watcher to file watcher

### DIFF
--- a/apps/tests/test_file_watch/CMakeLists.txt
+++ b/apps/tests/test_file_watch/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.7.2)
+set (CMAKE_CXX_STANDARD 17)
+
+set (PROJECT_NAME "Island-TestFileWatch")
+
+# Set global property (all targets are impacted)
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
+# set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
+
+project (${PROJECT_NAME})
+
+# set to number of worker threads if you wish to use multi-threaded rendering
+# add_compile_definitions( LE_MT=4 )
+
+# Vulkan Validation layers are enabled by default for Debug builds.
+# Uncomment the next line to disable loading Vulkan Validation Layers for Debug builds.
+# add_compile_definitions( SHOULD_USE_VALIDATION_LAYERS=false )
+
+# Point this to the base directory of your Island installation
+set (ISLAND_BASE_DIR "${PROJECT_SOURCE_DIR}/../../..")
+
+# Select which standard Island modules to use
+set(REQUIRES_ISLAND_LOADER ON )
+set(REQUIRES_ISLAND_CORE ON )
+
+# Loads Island framework, based on selected Island modules from above
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
+
+# Main application c++ file. Not much to see there,
+set (SOURCES main.cpp)
+
+# Add application module, and (optional) any other private
+# island modules which should not be part of the shared framework.
+add_subdirectory (test_file_watch_app)
+
+# Specify any optional modules from the standard framework here
+add_island_module(le_log)
+
+# Sets up Island framework linkage and housekeeping, based on user selections
+include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_epilog.in")
+
+# create a link to local resources
+link_resources(${PROJECT_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/local_resources)
+
+source_group(${PROJECT_NAME} FILES ${SOURCES})

--- a/apps/tests/test_file_watch/main.cpp
+++ b/apps/tests/test_file_watch/main.cpp
@@ -1,0 +1,33 @@
+#include "test_file_watch_app/test_file_watch_app.h"
+
+// ----------------------------------------------------------------------
+
+int main( int argc, char const *argv[] ) {
+
+	TestFileWatchApp::initialize();
+
+	{
+		// We instantiate TestFileWatchApp in its own scope - so that
+		// it will be destroyed before TestFileWatchApp::terminate
+		// is called.
+
+		TestFileWatchApp TestFileWatchApp{};
+
+		for ( ;; ) {
+
+#ifdef PLUGINS_DYNAMIC
+			le_core_poll_for_module_reloads();
+#endif
+			auto result = TestFileWatchApp.update();
+
+			if ( !result ) {
+				break;
+			}
+		}
+	}
+
+	// Must only be called once last TestFileWatchApp is destroyed
+	TestFileWatchApp::terminate();
+
+	return 0;
+}

--- a/apps/tests/test_file_watch/resources/file.txt
+++ b/apps/tests/test_file_watch/resources/file.txt
@@ -1,0 +1,1 @@
+change this file to exit test app

--- a/apps/tests/test_file_watch/test_file_watch_app/CMakeLists.txt
+++ b/apps/tests/test_file_watch/test_file_watch_app/CMakeLists.txt
@@ -1,0 +1,27 @@
+set (TARGET test_file_watch_app)
+
+set (SOURCES "test_file_watch_app.cpp")
+set (SOURCES ${SOURCES} "test_file_watch_app.h")
+
+if (${PLUGINS_DYNAMIC})
+
+    add_library(${TARGET} SHARED ${SOURCES})
+
+    
+    add_dynamic_linker_flags()
+
+    target_compile_definitions(${TARGET}  PUBLIC "PLUGINS_DYNAMIC")
+
+else()
+
+    # Adding a static library means to also add a linker dependency for our target
+    # to the library.
+    set (STATIC_LIBS ${STATIC_LIBS} ${TARGET} PARENT_SCOPE)
+
+    add_library(${TARGET} STATIC ${SOURCES})
+
+endif()
+
+target_link_libraries(${TARGET} PUBLIC ${LINKER_FLAGS})
+
+source_group(${TARGET} FILES ${SOURCES})

--- a/apps/tests/test_file_watch/test_file_watch_app/test_file_watch_app.cpp
+++ b/apps/tests/test_file_watch/test_file_watch_app/test_file_watch_app.cpp
@@ -1,0 +1,97 @@
+#include "test_file_watch_app.h"
+
+#include "le_file_watcher/le_file_watcher.h"
+#include "le_log/le_log.h"
+
+struct test_file_watch_app_o {
+	le::FileWatcher file_watcher;
+	LeLog           log{};
+	bool            quit = false;
+};
+
+typedef test_file_watch_app_o app_o;
+
+// ----------------------------------------------------------------------
+
+static void app_initialize(){};
+
+// ----------------------------------------------------------------------
+
+static void app_terminate(){};
+
+// ----------------------------------------------------------------------
+
+static bool file_callback( const char *path, void *user_data ) {
+	auto app = static_cast<test_file_watch_app_o *>( user_data );
+	app->log.info( "File modified '%s', will exit now", path );
+	app->quit = true;
+	return true;
+}
+
+static bool directory_callback( le::FileWatcher::Event event, const char *path, void *user_data ) {
+	auto        app    = static_cast<test_file_watch_app_o *>( user_data );
+	const char *action = nullptr;
+	switch ( event ) {
+	case le_file_watcher_api::Event::FILE_CREATED:
+		action = "file created";
+		break;
+	case le_file_watcher_api::Event::FILE_DELETED:
+		action = "file deleted";
+		break;
+	case le_file_watcher_api::Event::FILE_MODIFIED:
+		action = "file modified";
+		break;
+	case le_file_watcher_api::Event::FILE_MOVED:
+		action = "file moved";
+		break;
+	case le_file_watcher_api::Event::DIRECTORY_CREATED:
+		action = "folder created";
+		break;
+	case le_file_watcher_api::Event::DIRECTORY_DELETED:
+		action = "folder deleted";
+		break;
+	case le_file_watcher_api::Event::DIRECTORY_MOVED:
+		action = "folder moved";
+		break;
+	}
+	app->log.info( "%s %s", action, path );
+	return true;
+}
+
+// ----------------------------------------------------------------------
+
+static test_file_watch_app_o *test_file_watch_app_create() {
+	auto app = new ( test_file_watch_app_o );
+	app->log.info( "App Created" );
+	app->file_watcher.watch_file( "./local_resources/file.txt", file_callback, app );
+	app->file_watcher.watch_directory( "./local_resources", directory_callback, app );
+	return app;
+}
+
+// ----------------------------------------------------------------------
+
+static bool test_file_watch_app_update( test_file_watch_app_o *self ) {
+	self->file_watcher.poll();
+	return !self->quit; // keep app alive
+}
+
+// ----------------------------------------------------------------------
+
+static void test_file_watch_app_destroy( test_file_watch_app_o *self ) {
+	delete ( self ); // deletes camera
+}
+
+// ----------------------------------------------------------------------
+
+LE_MODULE_REGISTER_IMPL( test_file_watch_app, api ) {
+
+	auto  test_file_watch_app_api_i = static_cast<test_file_watch_app_api *>( api );
+	auto &test_file_watch_app_i     = test_file_watch_app_api_i->test_file_watch_app_i;
+
+	test_file_watch_app_i.initialize = app_initialize;
+	test_file_watch_app_i.terminate  = app_terminate;
+
+	test_file_watch_app_i.create  = test_file_watch_app_create;
+	test_file_watch_app_i.destroy = test_file_watch_app_destroy;
+	test_file_watch_app_i.update  = test_file_watch_app_update;
+}

--- a/apps/tests/test_file_watch/test_file_watch_app/test_file_watch_app.h
+++ b/apps/tests/test_file_watch/test_file_watch_app/test_file_watch_app.h
@@ -1,0 +1,62 @@
+#ifndef GUARD_test_file_watch_app_H
+#define GUARD_test_file_watch_app_H
+#endif
+
+#include "le_core/le_core.h"
+
+// depends on le_backend_vk. le_backend_vk must be loaded before this class is used.
+
+struct test_file_watch_app_o;
+
+// clang-format off
+struct test_file_watch_app_api {
+
+	struct test_file_watch_app_interface_t {
+		test_file_watch_app_o * ( *create               )();
+		void         ( *destroy                  )( test_file_watch_app_o *self );
+		bool         ( *update                   )( test_file_watch_app_o *self );
+		void         ( *initialize               )(); // static methods
+		void         ( *terminate                )(); // static methods
+	};
+
+	test_file_watch_app_interface_t test_file_watch_app_i;
+};
+// clang-format on
+
+LE_MODULE( test_file_watch_app );
+LE_MODULE_LOAD_DEFAULT( test_file_watch_app );
+
+#ifdef __cplusplus
+
+namespace test_file_watch_app {
+static const auto &api                 = test_file_watch_app_api_i;
+static const auto &test_file_watch_app_i = api -> test_file_watch_app_i;
+} // namespace test_file_watch_app
+
+class TestFileWatchApp : NoCopy, NoMove {
+
+	test_file_watch_app_o *self;
+
+  public:
+	TestFileWatchApp()
+	    : self( test_file_watch_app::test_file_watch_app_i.create() ) {
+	}
+
+	bool update() {
+		return test_file_watch_app::test_file_watch_app_i.update( self );
+	}
+
+	~TestFileWatchApp() {
+		test_file_watch_app::test_file_watch_app_i.destroy( self );
+	}
+
+	static void initialize() {
+		test_file_watch_app::test_file_watch_app_i.initialize();
+	}
+
+	static void terminate() {
+		test_file_watch_app::test_file_watch_app_i.terminate();
+	}
+};
+
+#endif

--- a/modules/le_file_watcher/le_file_watcher.h
+++ b/modules/le_file_watcher/le_file_watcher.h
@@ -11,22 +11,39 @@
 
 struct le_file_watcher_o;
 
-struct le_file_watcher_watch_settings {
-	const char *filePath                                             = nullptr;
-	bool ( *callback_fun )( const char *file_path, void *user_data ) = nullptr;
-	void *callback_user_data                                         = nullptr;
-};
-
 // clang-format off
 struct le_file_watcher_api {
 
+    enum class Event : int {
+        FILE_CREATED       = 0,
+        FILE_DELETED       = 1,
+        FILE_MODIFIED      = 2,
+        FILE_MOVED         = 3,
+        DIRECTORY_CREATED  = 4,
+        DIRECTORY_DELETED  = 5,
+        DIRECTORY_MOVED    = 6
+    };
+
+    struct directory_settings {
+        const char *path                                                              = nullptr;
+        bool ( *callback_fun )( Event event, const char *file_path, void *user_data ) = nullptr;
+        void *callback_user_data                                                      = nullptr;
+    };
+
+    struct file_settings {
+        const char *filePath                                             = nullptr;
+        bool ( *callback_fun )( const char *file_path, void *user_data ) = nullptr;
+        void *callback_user_data                                         = nullptr;
+    };
+
 	struct le_file_watcher_interface_t{
-		le_file_watcher_o *( *create             )();
+		le_file_watcher_o  *( *create             )();
 		void                ( *destroy            )( le_file_watcher_o *self );
 		
 		// returns unique id for the watch, -1 if unsuccessful.
-		int                 ( *add_watch          )( le_file_watcher_o *self, le_file_watcher_watch_settings const *settings );
-		
+		int                 ( *add_watch           )( le_file_watcher_o *self, file_settings const *settings );
+        int                 ( *add_watch_directory )( le_file_watcher_o *self, directory_settings const *settings );
+
 		bool                ( *remove_watch       )( le_file_watcher_o *self, int watch_id );
 		void                ( *poll_notifications )( le_file_watcher_o *self);
 	};
@@ -35,6 +52,9 @@ struct le_file_watcher_api {
 	
 };
 // clang-format on
+
+using le_file_watcher_watch_settings      = le_file_watcher_api::file_settings;
+using le_directory_watcher_watch_settings = le_file_watcher_api::directory_settings;
 
 LE_MODULE( le_file_watcher );
 
@@ -49,6 +69,44 @@ namespace le_file_watcher {
 static const auto &api               = le_file_watcher_api_i;
 static const auto &le_file_watcher_i = api -> le_file_watcher_i;
 } // namespace le_file_watcher
+
+namespace le {
+
+class FileWatcher : NoCopy, NoMove {
+	le_file_watcher_o *watcher;
+
+  public:
+	using Event = le_file_watcher_api::Event;
+
+	FileWatcher()
+	    : watcher( le_file_watcher::le_file_watcher_i.create() ) {
+	}
+
+	~FileWatcher() {
+		le_file_watcher::le_file_watcher_i.destroy( watcher );
+	}
+
+	int watch_file( const char *file_path, bool ( *callback_fun )( const char *file_path, void *user_data ), void *callback_userdata ) {
+		le_file_watcher_api::file_settings settings{ file_path, callback_fun, callback_userdata };
+		return le_file_watcher::le_file_watcher_i.add_watch( watcher, &settings );
+	}
+
+	int watch_directory( const char *file_path, bool ( *callback_fun )( Event event, const char *file_path, void *user_data ), void *callback_userdata ) {
+		le_file_watcher_api::directory_settings settings{ file_path, callback_fun, callback_userdata };
+		return le_file_watcher::le_file_watcher_i.add_watch_directory( watcher, &settings );
+	}
+
+	bool remove_watch( int watch_id ) {
+		return le_file_watcher::le_file_watcher_i.remove_watch( watcher, watch_id );
+	}
+
+	void poll() {
+		return le_file_watcher::le_file_watcher_i.poll_notifications( watcher );
+	}
+};
+
+} // namespace le
+
 #endif // !__cplusplus
 
 #endif // GUARD_FILE_SYSTEM_H

--- a/modules/le_file_watcher/le_file_watcher_linux.cpp
+++ b/modules/le_file_watcher/le_file_watcher_linux.cpp
@@ -15,10 +15,9 @@
 #	include <sys/inotify.h>
 #	include <unistd.h>
 
-
 // ----------------------------------------------------------------------
 
-struct Watch {
+struct FileWatch {
 	int                inotify_watch_handle = -1;
 	int                padding              = 0;
 	le_file_watcher_o *watcher_o;
@@ -29,12 +28,22 @@ struct Watch {
 	bool ( *callback_fun )( const char *path, void *user_data );
 };
 
+struct DirectoryWatch {
+	int                inotify_watch_handle = -1;
+	int                padding              = 0;
+	le_file_watcher_o *watcher_o;
+	std::string        path;
+	void *             callback_user_data = nullptr;
+	bool ( *callback_fun )( le_file_watcher_api::Event event, const char *path, void *user_data );
+};
+
 // ----------------------------------------------------------------------
 
 struct le_file_watcher_o {
-	int              inotify_socket_handle = -1;
-	int              padding               = 0;
-	std::list<Watch> mWatches;
+	int                       inotify_socket_handle = -1;
+	int                       padding               = 0;
+	std::list<FileWatch>      mFileWatches;
+	std::list<DirectoryWatch> mDirectoryWatches;
 };
 
 // ----------------------------------------------------------------------
@@ -49,10 +58,10 @@ static le_file_watcher_o *instance_create() {
 
 static void instance_destroy( le_file_watcher_o *instance ) {
 
-	for ( auto &w : instance->mWatches ) {
+	for ( auto &w : instance->mFileWatches ) {
 		inotify_rm_watch( instance->inotify_socket_handle, w.inotify_watch_handle );
 	}
-	instance->mWatches.clear();
+	instance->mFileWatches.clear();
 
 	if ( instance->inotify_socket_handle > 0 ) {
 		std::cout << "Closing inotify instance file handle: " << std::hex << instance->inotify_socket_handle << std::endl;
@@ -64,8 +73,8 @@ static void instance_destroy( le_file_watcher_o *instance ) {
 
 // ----------------------------------------------------------------------
 
-static int add_watch( le_file_watcher_o *instance, le_file_watcher_watch_settings const *settings ) noexcept {
-	Watch tmp;
+static int add_watch_file( le_file_watcher_o *instance, le_file_watcher_watch_settings const *settings ) noexcept {
+	FileWatch tmp;
 
 	auto tmp_path = std::filesystem::canonical( settings->filePath );
 
@@ -78,22 +87,46 @@ static int add_watch( le_file_watcher_o *instance, le_file_watcher_watch_setting
 
 	tmp.inotify_watch_handle = inotify_add_watch( instance->inotify_socket_handle, tmp.basename.c_str(), IN_CLOSE_WRITE );
 
-	instance->mWatches.emplace_back( std::move( tmp ) );
-	return tmp.inotify_watch_handle;
+	instance->mFileWatches.emplace_back( std::move( tmp ) );
+	return instance->mFileWatches.back().inotify_watch_handle; // tmp should not be used after move
+}
+
+static int add_watch_directory( le_file_watcher_o *instance, le_file_watcher_api::directory_settings const *settings ) noexcept {
+	DirectoryWatch tmp;
+
+	auto tmp_path = std::filesystem::canonical( settings->path );
+
+	tmp.path               = tmp_path.string();
+	tmp.watcher_o          = instance;
+	tmp.callback_fun       = settings->callback_fun;
+	tmp.callback_user_data = settings->callback_user_data;
+
+	tmp.inotify_watch_handle = inotify_add_watch( instance->inotify_socket_handle, tmp.path.c_str(), IN_CLOSE_WRITE | IN_CREATE | IN_DELETE | IN_MOVE );
+
+	instance->mDirectoryWatches.emplace_back( std::move( tmp ) );
+	return instance->mFileWatches.back().inotify_watch_handle;
 }
 
 // ----------------------------------------------------------------------
 
 static bool remove_watch( le_file_watcher_o *instance, int watch_id ) {
-	auto found_watch = std::find_if( instance->mWatches.begin(), instance->mWatches.end(), [ = ]( const Watch &w ) -> bool { return w.inotify_watch_handle == watch_id; } );
-	if ( found_watch != instance->mWatches.end() ) {
-		std::cout << "Removing inotify watch handle: " << std::hex << found_watch->inotify_watch_handle << std::endl;
+	auto found_watch = std::find_if( instance->mFileWatches.begin(), instance->mFileWatches.end(), [ = ]( const FileWatch &w ) -> bool { return w.inotify_watch_handle == watch_id; } );
+	if ( found_watch != instance->mFileWatches.end() ) {
+		std::cout << "Removing inotify file watch handle: " << std::hex << found_watch->inotify_watch_handle << std::endl;
 		inotify_rm_watch( instance->inotify_socket_handle, found_watch->inotify_watch_handle );
-		instance->mWatches.erase( found_watch );
+		instance->mFileWatches.erase( found_watch );
 		return true;
 	} else {
-		std::cout << "WARNING: " << __FUNCTION__ << ": could not find and thus remove watch with id:" << watch_id << std::endl;
-		return false;
+		auto found_dir_watch = std::find_if( instance->mDirectoryWatches.begin(), instance->mDirectoryWatches.end(), [ = ]( const DirectoryWatch &w ) -> bool { return w.inotify_watch_handle == watch_id; } );
+		if ( found_dir_watch != instance->mDirectoryWatches.end() ) {
+			std::cout << "Removing inotify directory watch handle: " << std::hex << found_dir_watch->inotify_watch_handle << std::endl;
+			inotify_rm_watch( instance->inotify_socket_handle, found_dir_watch->inotify_watch_handle );
+			instance->mDirectoryWatches.erase( found_dir_watch );
+			return true;
+		} else {
+			std::cout << "WARNING: " << __FUNCTION__ << ": could not find and thus remove watch with id:" << watch_id << std::endl;
+			return false;
+		}
 	}
 };
 
@@ -121,28 +154,78 @@ static void poll_notifications( le_file_watcher_o *instance ) {
 					continue;
 				}
 
-				std::string path          = ev->name;
-				const char *prev_filename = nullptr; // store previous filename to declutter printout
+				std::filesystem::path path          = ev->name;
+				const char *          prev_filename = nullptr; // store previous filename to declutter printout
 
-				// Only trigger on close-write
-				if ( ev->mask & IN_CLOSE_WRITE ) {
+				const auto log_trigger = [ & ]( const std::string &path, const std::string &src ) {
+					// Only print notice if it is for another filename:
+					if ( prev_filename != path.c_str() ) {
+						std::cout << "Watch triggered for: " << path << " [" << src << "]" << std::endl
+						          << std::flush;
+						prev_filename = path.c_str();
+					}
+				};
+
+				if ( ev->mask & IN_CREATE ) {
+					for ( auto const &w : instance->mDirectoryWatches ) {
+
+						if ( w.inotify_watch_handle == ev->wd ) {
+							log_trigger( path, w.path );
+
+							// Trigger Callback.
+							auto api_event =  std::filesystem::is_directory( w.path / path ) ? le_file_watcher_api::Event::DIRECTORY_CREATED : le_file_watcher_api::Event::FILE_CREATED;
+							( *w.callback_fun )( api_event, w.path.c_str(), w.callback_user_data );
+						}
+					}
+				} else if ( ev->mask & IN_DELETE ) {
+					for ( auto const &w : instance->mDirectoryWatches ) {
+
+						if ( w.inotify_watch_handle == ev->wd ) {
+
+							log_trigger( path, w.path );
+
+							// Trigger Callback.
+							auto api_event = path.extension().empty() ? le_file_watcher_api::Event::DIRECTORY_DELETED : le_file_watcher_api::Event::FILE_DELETED;
+							( *w.callback_fun )( api_event, w.path.c_str(), w.callback_user_data );
+						}
+					}
+				} else if ( ev->mask & IN_MOVE ) {
+					for ( auto const &w : instance->mDirectoryWatches ) {
+
+						if ( w.inotify_watch_handle == ev->wd ) {
+
+							log_trigger( path, w.path );
+
+							// Trigger Callback.
+							auto api_event = std::filesystem::is_directory( w.path / path ) ? le_file_watcher_api::Event::DIRECTORY_MOVED : le_file_watcher_api::Event::FILE_MOVED;
+							( *w.callback_fun )( api_event, w.path.c_str(), w.callback_user_data );
+						}
+					}
+				} else if ( ev->mask & IN_CLOSE_WRITE ) {
 
 					// We trigger *all* callbacks which watch the current file path
 					// For this, we must iterate through all watches and filter the
 					// ones which watch the event's file.
-					for ( auto const &w : instance->mWatches ) {
+					for ( auto const &w : instance->mFileWatches ) {
 
 						if ( w.inotify_watch_handle == ev->wd && w.filename == path ) {
 
-							// Only print notice if it is for another filename:
-							if ( prev_filename != path.c_str() ) {
-								std::cout << "Watch triggered for: " << path << " [" << w.basename << "]" << std::endl
-								          << std::flush;
-								prev_filename = path.c_str();
-							}
+							log_trigger( path, w.basename );
 
 							// Trigger Callback.
 							( *w.callback_fun )( w.path.c_str(), w.callback_user_data );
+						}
+					}
+
+					// now do the same for the directory watchers
+					for ( auto const &w : instance->mDirectoryWatches ) {
+
+						if ( w.inotify_watch_handle == ev->wd ) {
+
+							log_trigger( path, w.path );
+
+							// Trigger Callback.
+							( *w.callback_fun )( le_file_watcher_api::Event::FILE_MODIFIED, w.path.c_str(), w.callback_user_data );
 						}
 					}
 				}
@@ -157,13 +240,14 @@ static void poll_notifications( le_file_watcher_o *instance ) {
 // ----------------------------------------------------------------------
 
 LE_MODULE_REGISTER_IMPL( le_file_watcher, p_api ) {
-	auto  api                = reinterpret_cast<le_file_watcher_api *>( p_api );
-	auto &api_i              = api->le_file_watcher_i;
-	api_i.create             = instance_create;
-	api_i.destroy            = instance_destroy;
-	api_i.add_watch          = add_watch;
-	api_i.remove_watch       = remove_watch;
-	api_i.poll_notifications = poll_notifications;
+	auto  api                 = reinterpret_cast<le_file_watcher_api *>( p_api );
+	auto &api_i               = api->le_file_watcher_i;
+	api_i.create              = instance_create;
+	api_i.destroy             = instance_destroy;
+	api_i.add_watch           = add_watch_file;
+	api_i.add_watch_directory = add_watch_directory;
+	api_i.remove_watch        = remove_watch;
+	api_i.poll_notifications  = poll_notifications;
 };
 
 #endif


### PR DESCRIPTION
Add directory watching features to le_file_watch.

The API is a little bit of a mess for backwards compatibility. It all started with the problem that I wanted to have the Event enum within le_file_watcher_api. But then the directory settings had to be in there as well to have a clean access to Event. So file settings also had to move there to be consistent. thus the alias was born to not break anything.

There are also better ways to solve the implementation, but this should work, is hidden and fast enough.

no windows implementation yet though...