### PR TITLE
[readme] bump minimum vulkan-sdk version to 1.2.175

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ depends on the Vulkan SDK.
 
 ## Install Vulkan SDK 
 
-### Vulkan SDK >= `1.1.92.0`
+### Vulkan SDK >= `1.2.175`
 
 I recommend to install the latest Vulkan SDK via a package manager.
 Follow the installation instructions via:


### PR DESCRIPTION
VK_MAKE_API_VERSION as used in [le_instance_vk.cpp:448](https://github.com/tgfrerer/island/blob/wip/modules/le_backend_vk/le_instance_vk.cpp#L448) [was added in Vulkan-Header version 1.2.175](https://github.com/KhronosGroup/Vulkan-Headers/commit/e01b00657664ac34389d51b04c58dff3eb19a026#diff-e222ae95c2b0d5082b94d6086fb1c24da18ee31384c1a39840df3b9152023ee6)

On Debian Bullseye for example we have version 1.2.162. Then we would be fine according to the readme, but we'd get an error like:
`island/modules/le_backend_vk/le_instance_vk.cpp:448:30: error: ‘VK_MAKE_API_VERSION’ was not declared in this scope; did you mean ‘VK_MAKE_VERSION’?
  448 |      .setApplicationVersion( VK_MAKE_API_VERSION( 0, 0, 0, 0 ) )
      |                              ^~~~~~~~~~~~~~~~~~~
      |                              VK_MAKE_VERSION
`