### PR TITLE
[cmake] flatten module inclusion hierarchy

### DIFF
--- a/CMakeLists.txt.island_epilog.in
+++ b/CMakeLists.txt.island_epilog.in
@@ -49,13 +49,14 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PLUGIN_LIBS_DEPENDENCIES})
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") 
     # this is only needed for the GNU linker - it will force the linker to check all libraries for symbols,
     # not just the ones that are specified before a given library. 
     # more modern (and faster) linkers such as lld (llvm) or mold won't need this.
    target_link_libraries(${PROJECT_NAME} PRIVATE "-Wl,--start-group" $CACHE{STATIC_LIBRARIES} "-Wl,--end-group" )
 else()
-   target_link_libraries(${PROJECT_NAME} PRIVATE $CACHE{STATIC_LIBRARIES} )
+    # link static libs
+    target_link_libraries(${PROJECT_NAME} PRIVATE $CACHE{STATIC_LIBRARIES} )
 endif()
 
 

--- a/CMakeLists.txt.island_epilog.in
+++ b/CMakeLists.txt.island_epilog.in
@@ -1,4 +1,33 @@
+# Load all modules which where requested
+foreach( M IN LISTS MODULES_LIST )
+    request_island_module(${M})
+endforeach()
 
+
+while(REQUESTED_MODULES_LIST)
+    # remove any duplicates from requested modules 
+    list(REMOVE_DUPLICATES REQUESTED_MODULES_LIST)
+    # remove any modules from the requested list which are already in the loaded list
+    list(REMOVE_ITEM REQUESTED_MODULES_LIST ${LOADED_MODULES_LIST})
+    # store the requested_modules_list back to global
+    set( REQUESTED_MODULES_LIST ${REQUESTED_MODULES_LIST} ${MODULE_NAME} CACHE INTERNAL "requested modules_list" )  
+    
+    # message(STATUS "requested modules 1: ${REQUESTED_MODULES_LIST}")
+    
+    # Load all modules which where requested and which were not yet loaded
+    foreach( M IN LISTS REQUESTED_MODULES_LIST )
+        load_island_module(${M})
+    endforeach()
+    
+    # message(STATUS "requested modules 2: ${REQUESTED_MODULES_LIST}")
+    list(REMOVE_ITEM REQUESTED_MODULES_LIST ${LOADED_MODULES_LIST})
+    # store requested modules list back to global
+    set( REQUESTED_MODULES_LIST ${REQUESTED_MODULES_LIST} ${MODULE_NAME} CACHE INTERNAL "requested modules_list" )  
+    # repeat this until no more modules are requested.
+    
+    # message(STATUS "requested modules 3: ${REQUESTED_MODULES_LIST}")
+    # remove any elements from requested modules which are now present in loaded modules
+endwhile(REQUESTED_MODULES_LIST)
 
 # print_current_includes()
 
@@ -17,8 +46,6 @@ endif()
 
 # we need to link in the dynamic linking library so we can use dynamic linking
 target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-
-# target_link_libraries("${ISLAND_BASE_DIR}modules/le_renderer" "${ISLAND_BASE_DIR}modules/le_log")
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PLUGIN_LIBS_DEPENDENCIES})
 

--- a/CMakeLists.txt.island_prolog.in
+++ b/CMakeLists.txt.island_prolog.in
@@ -14,6 +14,13 @@ else()
     set(PLUGINS_DYNAMIC OFF CACHE BOOL "Use dynamic linking for all plugins")
 endif()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # use lld linker for clang-compiled binary - it's faster than gnu ld,
+    # and you don't have to worry about the linking order for libraries.
+    set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-fuse-ld=lld -Wno-unused-command-line-argument")
+    set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} "-fuse-ld=lld -Wno-unused-command-line-argument")
+endif()
+
 set ( STATIC_LIBRARIES "" CACHE INTERNAL "static_libraries" )
 set ( DEPENDENCY_DEPTH 0 CACHE INTERNAL "current depth in dependency hierarchy" )
 
@@ -85,9 +92,6 @@ set ( MODULE_LOCATIONS_LIST CACHE INTERNAL "module_locations_list")
 # Set default island module location
 add_island_module_location("${ISLAND_BASE_DIR}/modules")
 
-# We will store all requested module names in this list, and then load modules based on this list
-set ( MODULES_LIST )
-
 # We will store all loaded module names in this global list, so that we can make sure that modules don't get loaded more than once.
 set ( LOADED_MODULES_LIST CACHE INTERNAL "loaded_modules_list" )
 
@@ -131,11 +135,11 @@ endif()
 # Add required modules to modules list based on user flags
 #
 if (REQUIRES_ISLAND_LOADER)
-    list (APPEND MODULES_LIST ${ISLAND_LOADER_MODULES})
+    list (APPEND REQUESTED_MODULES_LIST ${ISLAND_LOADER_MODULES})
 endif()
  
 if (REQUIRES_ISLAND_CORE)
-   list (APPEND MODULES_LIST ${CORE_ISLAND_MODULES})
+    list (APPEND REQUESTED_MODULES_LIST ${CORE_ISLAND_MODULES})
 endif()
 
 # ----------------------------------------------------------------------
@@ -224,7 +228,7 @@ macro(request_island_module MODULE_NAME)
     
     if (NOT ${MODULE_NAME} IN_LIST LOADED_MODULES_LIST)
         # prepend module name to loaded_modules_list in global scope
-        set( REQUESTED_MODULES_LIST ${REQUESTED_MODULES_LIST} ${MODULE_NAME} CACHE INTERNAL "requested modules_list" )        
+        set( REQUESTED_MODULES_LIST ${MODULE_NAME} ${REQUESTED_MODULES_LIST} CACHE INTERNAL "requested modules_list" )        
         include_island_module( ${MODULE_NAME} FALSE )
     else()
         include_island_module( ${MODULE_NAME} FALSE )
@@ -346,3 +350,5 @@ macro(add_dynamic_linker_flags)
 endmacro(add_dynamic_linker_flags)
 
 # ----------------------------------------------------------------------
+
+set( REQUESTED_MODULES_LIST ${REQUESTED_MODULES_LIST} ${MODULE_NAME} CACHE INTERNAL "requested modules_list" )  

--- a/CMakeLists.txt.island_prolog.in
+++ b/CMakeLists.txt.island_prolog.in
@@ -91,6 +91,11 @@ set ( MODULES_LIST )
 # We will store all loaded module names in this global list, so that we can make sure that modules don't get loaded more than once.
 set ( LOADED_MODULES_LIST CACHE INTERNAL "loaded_modules_list" )
 
+# We will store all requested module names in this global list, to keep track of all modules which have been requested.
+# once this list is empty we know there are no more modules which need to be loaded.
+set ( REQUESTED_MODULES_LIST CACHE INTERNAL "requested_modules_list" )
+
+
 # These modules are always loaded - they control the plugin system.
 set ( ISLAND_LOADER_MODULES le_log;le_file_watcher;le_core )
 
@@ -133,6 +138,19 @@ if (REQUIRES_ISLAND_CORE)
    list (APPEND MODULES_LIST ${CORE_ISLAND_MODULES})
 endif()
 
+# ----------------------------------------------------------------------
+
+macro(add_static_lib LIB_NAME)
+
+    if (NOT ${LIB_NAME} IN_LIST STATIC_LIBRARIES})
+        set ( STATIC_LIBRARIES ${LIB_NAME} $CACHE{STATIC_LIBRARIES} CACHE INTERNAL "static_libraries" )
+        # message( STATUS "${TMP_INDENT}>>> Static libs: ${STATIC_LIBRARIES}")
+    else()
+        # set (STATIC_LIBRARIES ${STATIC_LIBRARIES} PARENT_SCOPE)
+        message( STATUS "[ NOTE ] Rejecting extra static lib addition: `${LIB_NAME}` - lib already present."  )
+    endif()
+
+endmacro(add_static_lib LIB_NAME)
 
 # ----------------------------------------------------------------------
 
@@ -161,7 +179,6 @@ function(find_module MODULE_LOCATION MODULE_NAME )
     endforeach()
 endfunction()
 
-
 # ----------------------------------------------------------------------
 # Loads a requested module - note that this may recursively 
 # trigger loading more modules, as modules are added via 
@@ -180,14 +197,14 @@ macro(include_island_module MODULE_NAME SHOULD_ADD)
         get_directory_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} INCLUDE_DIRECTORIES)
 
         if (NOT ${MODULE_LOCATION} IN_LIST dirs)
-            message(STATUS "${TMP_INDENT}Loading module  : ${MODULE_NAME}")
+            # message(STATUS "${TMP_INDENT}Loading module  : ${MODULE_NAME}")
             include_directories( "${MODULE_LOCATION}")
             # message(STATUS "${TMP_INDENT}+++ Adding include : ${MODULE_LOCATION}")
         endif()
 
         # set_directory_properties()
         if ( ${SHOULD_ADD} )
-            message(STATUS "${TMP_INDENT}Adding subdirectory  : ${MODULE_LOCATION}")
+            message(STATUS "${TMP_INDENT} ${MODULE_NAME}")
             add_subdirectory( ${MODULE_LOCATION} ${MODULE_NAME} )
         endif()
 
@@ -199,37 +216,39 @@ macro(include_island_module MODULE_NAME SHOULD_ADD)
 
 endmacro()
 
-
 # ----------------------------------------------------------------------
 # Call this macro from other modules to establish a dependency.
 # Adds a module name to list of requested modules, 
 # checks whether a module was already requested to prevent duplicates.
-macro(add_island_module MODULE_NAME)
+macro(request_island_module MODULE_NAME)
     
     if (NOT ${MODULE_NAME} IN_LIST LOADED_MODULES_LIST)
         # prepend module name to loaded_modules_list in global scope
-        set( LOADED_MODULES_LIST ${LOADED_MODULES_LIST} ${MODULE_NAME} CACHE INTERNAL "loaded_modules_list" )        
-        include_island_module( ${MODULE_NAME} TRUE )
+        set( REQUESTED_MODULES_LIST ${REQUESTED_MODULES_LIST} ${MODULE_NAME} CACHE INTERNAL "requested modules_list" )        
+        include_island_module( ${MODULE_NAME} FALSE )
     else()
         include_island_module( ${MODULE_NAME} FALSE )
         # message(STATUS "[ NOTE ] Rejecting add_island_module request: `${MODULE_NAME}` - Module already present."  )
     endif()
 
-endmacro(add_island_module)
+endmacro(request_island_module)
 
 # ----------------------------------------------------------------------
-
-macro(add_static_lib LIB_NAME)
-
-    if (NOT ${LIB_NAME} IN_LIST STATIC_LIBRARIES})
-        set ( STATIC_LIBRARIES ${LIB_NAME} $CACHE{STATIC_LIBRARIES} CACHE INTERNAL "static_libraries" )
-        # message( STATUS "${TMP_INDENT}>>> Static libs: ${STATIC_LIBRARIES}")
+# Call this macro from other modules to establish a dependency.
+# Adds a module name to list of requested modules, 
+# checks whether a module was already requested to prevent duplicates.
+macro(load_island_module MODULE_NAME)
+    
+    if (NOT ${MODULE_NAME} IN_LIST LOADED_MODULES_LIST)
+        # prepend module name to loaded_modules_list in global scope
+        set( LOADED_MODULES_LIST ${LOADED_MODULES_LIST} ${MODULE_NAME} CACHE INTERNAL "loaded_modules_list" )     
+        include_island_module( ${MODULE_NAME} TRUE )
     else()
-        # set (STATIC_LIBRARIES ${STATIC_LIBRARIES} PARENT_SCOPE)
-        message( STATUS "[ NOTE ] Rejecting extra static lib addition: `${LIB_NAME}` - lib already present."  )
+        include_island_module( ${MODULE_NAME} FALSE )
+        message(STATUS "[ NOTE ] Rejecting load_island_module request: `${MODULE_NAME}` - Module already present."  )
     endif()
 
-endmacro(add_static_lib LIB_NAME)
+endmacro(load_island_module)
 
 # ----------------------------------------------------------------------
 
@@ -241,9 +260,9 @@ macro (depends_on_island_module MODULE_NAME)
     string(REPEAT "  " ${DEPENDENCY_DEPTH} TMP_INDENT)
 
     get_filename_component(THIS_MODULE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE )
-    message(STATUS "${TMP_INDENT}*** ${THIS_MODULE_NAME} Depends on Module: ${MODULE_NAME}")
+    message(STATUS "${TMP_INDENT} ${THIS_MODULE_NAME} ← ${MODULE_NAME}")
 
-    add_island_module(${MODULE_NAME})
+    request_island_module(${MODULE_NAME})
 
     math( EXPR TMP_DEPENDENCY_DEPTH "$CACHE{DEPENDENCY_DEPTH}-1")
     set ( DEPENDENCY_DEPTH ${TMP_DEPENDENCY_DEPTH} CACHE INTERNAL "current depth in dependency hierarchy" )
@@ -327,9 +346,3 @@ macro(add_dynamic_linker_flags)
 endmacro(add_dynamic_linker_flags)
 
 # ----------------------------------------------------------------------
-
-
-# Load all modules which where requested
-foreach( M IN LISTS MODULES_LIST )
-    add_island_module(${M})
-endforeach()

--- a/apps/examples/test_log/CMakeLists.txt
+++ b/apps/examples/test_log/CMakeLists.txt
@@ -29,13 +29,7 @@ include ("${ISLAND_BASE_DIR}/CMakeLists.txt.island_prolog.in")
 # Add custom module search paths
 # add_island_module_location(${PROJECT_SOURCE_DIR}/../../modules)
 
-# Specify any used modules here - you may reference any module 
-# found in the default Island modules/ directory, or found in any 
-# directories you specified via `add_island_module_location` above.
-#
-add_island_module(le_log)
-
-# Main application c++ file. Not much to see there,
+# Main application c++ file. Not much to see there
 set (SOURCES main.cpp)
 
 # Add application module, and (optional) any other private

--- a/apps/examples/test_log/test_log_app/CMakeLists.txt
+++ b/apps/examples/test_log/test_log_app/CMakeLists.txt
@@ -1,3 +1,6 @@
+depends_on_island_module(le_log)
+
+
 set (TARGET test_log_app)
 
 set (SOURCES "test_log_app.cpp")

--- a/apps/examples/test_log/test_log_app/test_log_app.cpp
+++ b/apps/examples/test_log/test_log_app/test_log_app.cpp
@@ -30,10 +30,10 @@ static test_log_app_o* test_log_app_create() {
 }
 
 // ----------------------------------------------------------------------
+static auto logger_2 = LeLog( "logger_2" );
 
 static bool test_log_app_update( test_log_app_o* self ) {
 
-	auto logger_2 = LeLog( "logger_2" );
 	logger_2.set_level( LeLog::Level::eInfo );
 	logger_2.info( "Logger_2 says hello from frame: %d", self->frame_counter );
 	std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
@@ -48,6 +48,7 @@ static bool test_log_app_update( test_log_app_o* self ) {
 	self->frame_counter++;
 
 	if ( self->frame_counter > 3 ) {
+		logger_2.warn( "Bye, then..." );
 		return false;
 	} else {
 


### PR DESCRIPTION
When including dependent modules recursively including subdirectories
led to very deep build trees.

This is not very pretty, and can lead to compile issues on windows,
where the effective length of paths appears to be limited at 260
characters.

To fix this, this change applies a new algorithm for resolving
dependencies, which resolves dependencies in a two-step manner,
flattening the build tree.

We can do this because the clang linker does not require topological
order for build artifacts, and we use the `--[start|end]group` flag for
the gcc linker, which forces symbol resolution to be a bit more lenient
about the order in which artifacts are presented to the linker.