### PR TITLE
Fix querying correct device properties from device list

### DIFF
--- a/modules/le_backend_vk/le_device_vk.cpp
+++ b/modules/le_backend_vk/le_device_vk.cpp
@@ -243,7 +243,7 @@ static le_device_o* device_create( le_backend_vk_instance_o* backend_instance, c
 
 		for ( auto d = deviceList.begin(); d != deviceList.end(); d++ ) {
 			VkPhysicalDeviceProperties device_properties{};
-			vkGetPhysicalDeviceProperties( self->vkPhysicalDevice, &device_properties );
+			vkGetPhysicalDeviceProperties( *d, &device_properties );
 			if ( device_properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU ) {
 				self->vkPhysicalDevice = *d;
 				break;


### PR DESCRIPTION
Small fix to picking vulkan device. The device properties were always queried from the fallback device (aka first one on the list). In my case it was the integrated GPU and so this one was always picked.