### PR TITLE
Fix le_image_decoder_read_pixels  in le_pixels module

### DIFF
--- a/modules/le_pixels/le_pixels.cpp
+++ b/modules/le_pixels/le_pixels.cpp
@@ -181,7 +181,7 @@ static bool le_image_decoder_read_pixels( le_image_decoder_o* self, uint8_t* pix
 	void* pixel_data = nullptr;
 	if ( pixel_data_type == le_num_type::eU8 || pixel_data_type == le_num_type::eI8 ) {
 		pixel_data = stbi_load( self->image_path.c_str(), &self->image_width, &self->image_height, &num_channels, num_channels );
-	} else if ( pixel_data_type == le_num_type::eU16 || pixel_data_type == le_num_type::eI16 ) {
+	} else if ( pixel_data_type == le_num_type::eU16 || pixel_data_type == le_num_type::eI16 || pixel_data_type == le_num_type::eF16 ) {
 		pixel_data = stbi_load_16( self->image_path.c_str(), &self->image_width, &self->image_height, &num_channels, num_channels );
 	} else if ( pixel_data_type == le_num_type::eF32 ) {
 		pixel_data = stbi_loadf( self->image_path.c_str(), &self->image_width, &self->image_height, &num_channels, num_channels );


### PR DESCRIPTION
Fixes `hello_world` example with the following error message:
```
[ le_pixels                 | INFO    ] Created image decoder for file './local_resources/images/earthNormalMap_8k-sobel.tga'
[ resource_manager          | INFO    ] File './local_resources/images/earthNormalMap_8k-sobel.tga' -> adjusting imported image format from R8G8B8Unorm to: R16G16B16A16Unorm
[ le_pixels                 | ERROR   ] Could not load image './local_resources/images/earthNormalMap_8k-sobel.tga'
```

